### PR TITLE
Fix MSVC build on 64-bit

### DIFF
--- a/src/build/common.gypi
+++ b/src/build/common.gypi
@@ -894,7 +894,7 @@
         ],
         'msvs_cygwin_dirs': ['<(DEPTH)/third_party/cygwin'],
         'msvs_disabled_warnings': [
-          4100, 4127, 4396, 4503, 4512, 4819, 4995, 4702
+          4091, 4100, 4127, 4366, 4396, 4503, 4512, 4819, 4995, 4702
         ],
         'msvs_settings': {
           'VCCLCompilerTool': {

--- a/src/client/windows/unittests/exception_handler_death_test.cc
+++ b/src/client/windows/unittests/exception_handler_death_test.cc
@@ -82,7 +82,7 @@ void ExceptionHandlerDeathTest::SetUp() {
   // The test case name is exposed as a c-style string,
   // convert it to a wchar_t string.
   int dwRet = MultiByteToWideChar(CP_ACP, 0, test_info->name(),
-                                  strlen(test_info->name()),
+                                  int(strlen(test_info->name())),
                                   test_name_wide,
                                   MAX_PATH);
   if (!dwRet) {
@@ -293,8 +293,8 @@ wstring find_minidump_in_directory(const wstring &directory) {
   wstring filename;
   do {
     const wchar_t extension[] = L".dmp";
-    const int extension_length = sizeof(extension) / sizeof(extension[0]) - 1;
-    const int filename_length = wcslen(find_data.cFileName);
+    const size_t extension_length = sizeof(extension) / sizeof(extension[0]) - 1;
+    const size_t filename_length = wcslen(find_data.cFileName);
     if (filename_length > extension_length &&
     wcsncmp(extension,
             find_data.cFileName + filename_length - extension_length,

--- a/src/client/windows/unittests/exception_handler_test.cc
+++ b/src/client/windows/unittests/exception_handler_test.cc
@@ -120,7 +120,7 @@ void ExceptionHandlerTest::SetUp() {
   // THe test case name is exposed to use as a c-style string,
   // But we might be working in UNICODE here on Windows.
   int dwRet = MultiByteToWideChar(CP_ACP, 0, test_info->name(),
-                                  strlen(test_info->name()),
+                                  int(strlen(test_info->name())),
                                   test_name_wide,
                                   MAX_PATH);
   if (!dwRet) {

--- a/src/client/windows/unittests/minidump_test.cc
+++ b/src/client/windows/unittests/minidump_test.cc
@@ -93,7 +93,7 @@ class MinidumpTest: public testing::Test {
         STATUS_ACCESS_VIOLATION,  // ExceptionCode
         0,  // ExceptionFlags
         NULL,  // ExceptionRecord;
-        reinterpret_cast<void*>(0xCAFEBABE),  // ExceptionAddress;
+        reinterpret_cast<void*>(size_t(0xCAFEBABE)),  // ExceptionAddress;
         2,  // NumberParameters;
         { EXCEPTION_WRITE_FAULT, reinterpret_cast<ULONG_PTR>(this) }
     };

--- a/src/processor/minidump.cc
+++ b/src/processor/minidump.cc
@@ -380,7 +380,7 @@ string TimeTToUTCString(time_t tt) {
 #endif
 
   char timestr[20];
-  int rv = strftime(timestr, 20, "%Y-%m-%d %H:%M:%S", &timestruct);
+  size_t rv = strftime(timestr, 20, "%Y-%m-%d %H:%M:%S", &timestruct);
   if (rv == 0) {
     return string();
   }
@@ -2034,10 +2034,10 @@ string MinidumpModule::debug_file() const {
         // that this method (and all other methods in the Minidump family)
         // return.
 
-        unsigned int bytes =
+        size_t bytes =
             module_.misc_record.data_size - MDImageDebugMisc_minsize;
         if (bytes % 2 == 0) {
-          unsigned int utf16_words = bytes / 2;
+          size_t utf16_words = bytes / 2;
 
           // UTF16ToUTF8 expects a vector<uint16_t>, so create a temporary one
           // and copy the UTF-16 data into it.
@@ -2392,8 +2392,8 @@ const MDImageDebugMisc* MinidumpModule::GetMiscRecord(uint32_t* size) {
         // There is a potential alignment problem, but shouldn't be a problem
         // in practice due to the layout of MDImageDebugMisc.
         uint16_t* data16 = reinterpret_cast<uint16_t*>(&(misc_record->data));
-        unsigned int dataBytes = module_.misc_record.data_size -
-                                 MDImageDebugMisc_minsize;
+        size_t dataBytes = module_.misc_record.data_size -
+                           MDImageDebugMisc_minsize;
         Swap(data16, dataBytes);
       }
     }
@@ -4004,7 +4004,7 @@ bool MinidumpMiscInfo::Read(uint32_t expected_size) {
       return false;
     }
 
-    if (!minidump_->SeekSet(saved_position + padding)) {
+    if (!minidump_->SeekSet(saved_position + off_t(padding))) {
       BPLOG(ERROR) << "MinidumpMiscInfo could not seek past the miscellaneous "
                    << "info structure";
       return false;
@@ -4538,7 +4538,7 @@ bool MinidumpMemoryInfoList::Read(uint32_t expected_size) {
     infos_ = infos.release();
   }
 
-  info_count_ = header_number_of_entries;
+  info_count_ = uint32_t(header_number_of_entries);
 
   valid_ = true;
   return true;
@@ -4730,7 +4730,7 @@ bool MinidumpLinuxMapsList::Read(uint32_t expected_size) {
 
   // Set instance variables.
   maps_ = maps.release();
-  maps_count_ = maps_->size();
+  maps_count_ = uint32_t(maps_->size());
   valid_ = true;
   return true;
 }

--- a/src/processor/range_map-inl.h
+++ b/src/processor/range_map-inl.h
@@ -256,7 +256,7 @@ bool RangeMap<AddressType, EntryType>::RetrieveRangeAtIndex(
 
 template<typename AddressType, typename EntryType>
 int RangeMap<AddressType, EntryType>::GetCount() const {
-  return map_.size();
+  return int(map_.size());
 }
 
 

--- a/src/tools/windows/converter/ms_symbol_server_converter.cc
+++ b/src/tools/windows/converter/ms_symbol_server_converter.cc
@@ -72,16 +72,16 @@ bool GUIDOrSignatureIdentifier::InitializeFromString(
 
   if (length > 32 && length <= 40) {
     // GUID
+    unsigned int d2, d3, d4[8];
     if (SSCANF(identifier.c_str(),
                "%08X%04X%04X%02X%02X%02X%02X%02X%02X%02X%02X%X",
-               &guid_.Data1, &guid_.Data2, &guid_.Data3,
-               &guid_.Data4[0], &guid_.Data4[1],
-               &guid_.Data4[2], &guid_.Data4[3],
-               &guid_.Data4[4], &guid_.Data4[5],
-               &guid_.Data4[6], &guid_.Data4[7],
-               &age_) != 12) {
+               &guid_.Data1, &d2, &d3, &d4[0], &d4[1], &d4[2], &d4[3],
+               &d4[4], &d4[5], &d4[6], &d4[7], &age_) != 12) {
       return false;
     }
+    guid_.Data2 = static_cast<unsigned short>(d2);
+    guid_.Data3 = static_cast<unsigned short>(d3);
+    memcpy(guid_.Data4, d4, sizeof(guid_.Data4));
 
     type_ = TYPE_GUID;
   } else if (length > 8 && length <= 15) {
@@ -500,7 +500,7 @@ MSSymbolServerConverter::LocateAndConvertSymbolFile(
   if (!WindowsStringUtils::safe_mbstowcs(pdb_file, &pdb_file_w)) {
     fprintf(stderr,
             "LocateAndConvertSymbolFile: "
-                "WindowsStringUtils::safe_mbstowcs failed for %s\n",
+                "WindowsStringUtils::safe_mbstowcs failed for %ws\n",
             pdb_file_w.c_str());
     return LOCATE_FAILURE;
   }


### PR DESCRIPTION
Mostly int<->size_t implicit conversions.

Warning 4366 (The result of the unary '&' operator may be unaligned)
appears in minidump.cc:907, but I don't know why. It looks aligned to me.

Change-Id: I641942adc324f8f9832b20662083dc83498688a8