### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,17 @@ To update an existing checkout to a newer revision, you can
 `git pull` as usual, but then you should run `gclient sync` to ensure that the
 dependent repos are up-to-date.
 
+Alternatively, you can build and install breakpad using [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager:
+```sh
+git clone https://github.com/Microsoft/vcpkg.git
+cd vcpkg
+./bootstrap-vcpkg.sh
+./vcpkg integrate install
+./vcpkg install breakpad
+```
+The breakpad port in vcpkg is kept up to date by Microsoft team members and community contributors.
+If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 ## To request change review
 
 1.  Follow the steps above to get the source and build it.


### PR DESCRIPTION
Breakpad is available as a port in VCPKG , documenting the install process here will help users get started by providing a single set of commands to build breakpad, ready to be included in their projects.

VCPKG is a C++ library manager that simplifies installation for breakpad and other project dependencies, we also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and here is what the port script looks like. We try to keep the library maintained as close as possible to the original library.
