### PR TITLE
GHA: add initial workflow for building the tools

### DIFF
--- a/.github/workflows/bcny-tools.yml
+++ b/.github/workflows/bcny-tools.yml
@@ -1,0 +1,75 @@
+
+name: BreakPad Tools
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  windows:
+    runs-on: windows-latest
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        include:
+          - arch: 'AMD64'
+            platform: 'x64'
+          - arch: 'ARM64'
+            platform: 'ARM64'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: compnerd/gha-setup-vsdevenv@main
+        with:
+          host_arch: amd64
+          arch: ${{ matrix.arch }}
+
+      - context:
+        outputs:
+          git_revision: ${{ steps.context.outputs.git_revision }}
+        run: |
+          Write-Host "git_revision=$(git log -1 --format=%h)" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+      - name: Configure
+        run: >
+          cmake -A ${{ matrix.platform }} `
+                -B out `
+                -G "Visual Studio 17 2022" `
+                -S ${{ github.workspace }}/src/tools/windows/dump_syms
+      - name: Build dump_syms
+        run: cmake --build out --config RelWithDebInfo
+
+      - name: Stage dump_syms
+        run: |
+          New-Item -ItemType Directory -Path breakpad-tools\bin -Force | Out-Null
+          Copy-Item out\RelWithDebInfo\dump_syms.exe breakpad-tools-${{ context.outputs.git_revision }}\bin
+          Copy-Item out\RelWithDebInfo\dump_syms.pdb breakpad-tools-${{ context.outputs.git_revision }}\bin
+
+      - name: actions/upload-artifact@v3
+        with:
+          name: breakpad_tools-windows-${{ matrix.arch }}
+          path: breakpad-tools-${{ context.outputs.git_revision }}
+
+      - uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        id: create_release
+        with:
+          draft: false
+          prerelease: true
+          release_name: breakpad_tools-${{ context.outputs.git_revision }}
+          tag_name: breakpad_tools-${{ context.outputs.git_revision }}
+
+      - uses: actions/upload-release-asset@v1.0.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          asset_content_type: application/octet-stream
+          asset_name: breakpad_tools-${{ context.outputs.git_revision }}
+          asset_path: ${{ github.workspace }}/breakpad-tools
+          upload_url: ${{ steps.create_release.outputs.upload_url }}

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@
 .svn/
 
 # Ignore common compiled artifacts.
+*.sw?
 *~
 *.dwo
 *.o

--- a/src/tools/windows/dump_syms/CMakeLists.txt
+++ b/src/tools/windows/dump_syms/CMakeLists.txt
@@ -1,0 +1,27 @@
+
+cmake_minimum_required(VERSION 3.26)
+project(dump_syms
+  LANGUAGES CXX)
+
+list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/modules)
+
+find_package(DiaSDK)
+
+add_executable(dump_syms
+  dump_syms.cc)
+target_sources(dump_syms PRIVATE
+  ../../../common/windows/dia_util.cc
+  ../../../common/windows/guid_string.cc
+  ../../../common/windows/omap.cc
+  ../../../common/windows/pdb_source_line_writer.cc
+  ../../../common/windows/pe_source_line_writer.cc
+  ../../../common/windows/pe_util.cc
+  ../../../common/windows/string_utils.cc)
+target_include_directories(dump_syms PRIVATE
+  ../../..
+  ${DIASDK_INCLUDE_DIR})
+target_link_libraries(dump_syms PRIVATE
+  DbgHelp
+  ImageHlp
+  ${DIASDK_LIBRARIES})
+

--- a/src/tools/windows/dump_syms/cmake/modules/FindDiaSDK.cmake
+++ b/src/tools/windows/dump_syms/cmake/modules/FindDiaSDK.cmake
@@ -1,0 +1,49 @@
+# Find the DIA SDK path.
+# It will typically look something like this:
+# C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\DIA SDK\include
+
+# CMAKE_GENERATOR_INSTANCE has the location of Visual Studio used
+# i.e. C:/Program Files (x86)/Microsoft Visual Studio/2019/Community
+set(VS_PATH ${CMAKE_GENERATOR_INSTANCE})
+get_filename_component(VS_DIA_INC_PATH "${VS_PATH}/DIA SDK/include" ABSOLUTE CACHE)
+
+# Starting in VS 15.2, vswhere is included.
+# Unclear what the right component to search for is, might be Microsoft.VisualStudio.Component.VC.DiagnosticTools
+# (although the friendly name of that is C++ profiling tools).  The toolset is the most likely target.
+set(PROGRAMFILES_X86 "ProgramFiles(x86)")
+execute_process(
+  COMMAND "$ENV{${PROGRAMFILES_X86}}/Microsoft Visual Studio/Installer/vswhere.exe" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+  OUTPUT_VARIABLE VSWHERE_LATEST
+  ERROR_QUIET
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+
+find_path(DIASDK_INCLUDE_DIR    # Set variable DIASDK_INCLUDE_DIR
+          dia2.h                # Find a path with dia2.h
+          HINTS "${VS_DIA_INC_PATH}"
+          HINTS "${VSWHERE_LATEST}/DIA SDK/include"
+          HINTS "${MSVC_DIA_SDK_DIR}/include"
+          DOC "path to DIA SDK header files"
+          )
+
+
+if ((CMAKE_GENERATOR_PLATFORM STREQUAL "x64") OR ("${CMAKE_C_COMPILER_ARCHITECTURE_ID}" STREQUAL "x64"))
+  find_library(DIASDK_GUIDS_LIBRARY NAMES diaguids.lib HINTS ${DIASDK_INCLUDE_DIR}/../lib/amd64 )
+elseif ((CMAKE_GENERATOR_PLATFORM STREQUAL "ARM") OR ("${CMAKE_C_COMPILER_ARCHITECTURE_ID}" STREQUAL "ARM"))
+  find_library(DIASDK_GUIDS_LIBRARY NAMES diaguids.lib HINTS ${DIASDK_INCLUDE_DIR}/../lib/arm )
+elseif ((CMAKE_GENERATOR_PLATFORM MATCHES "ARM64.*") OR ("${CMAKE_C_COMPILER_ARCHITECTURE_ID}" MATCHES "ARM64.*"))
+  find_library(DIASDK_GUIDS_LIBRARY NAMES diaguids.lib HINTS ${DIASDK_INCLUDE_DIR}/../lib/arm64 )
+else ((CMAKE_GENERATOR_PLATFORM STREQUAL "x64") OR ("${CMAKE_C_COMPILER_ARCHITECTURE_ID}" STREQUAL "x64"))
+  find_library(DIASDK_GUIDS_LIBRARY NAMES diaguids.lib HINTS ${DIASDK_INCLUDE_DIR}/../lib )
+endif((CMAKE_GENERATOR_PLATFORM STREQUAL "x64") OR ("${CMAKE_C_COMPILER_ARCHITECTURE_ID}" STREQUAL "x64"))
+
+set(DIASDK_LIBRARIES ${DIASDK_GUIDS_LIBRARY})
+set(DIASDK_INCLUDE_DIRS ${DIASDK_INCLUDE_DIR})
+
+include(FindPackageHandleStandardArgs)
+# handle the QUIETLY and REQUIRED arguments and set DIASDK_FOUND to TRUE
+# if all listed variables are TRUE
+find_package_handle_standard_args(DiaSDK  DEFAULT_MSG
+                                  DIASDK_LIBRARIES DIASDK_INCLUDE_DIR)
+
+mark_as_advanced(DIASDK_INCLUDE_DIRS DIASDK_LIBRARIES)


### PR DESCRIPTION
Introduce a build system and build workflow for building dump_syms for Windows. This is to enable us to consider breakpad symbols for Arc as a means of getting undecorated symbols.